### PR TITLE
Switch to async meilisearch

### DIFF
--- a/backend/api/app/api/v1/resources/recipes.py
+++ b/backend/api/app/api/v1/resources/recipes.py
@@ -1,4 +1,4 @@
-import meilisearch
+import meilisearch_python_async
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi_pagination import Page, paginate
 from loguru import logger
@@ -44,7 +44,7 @@ async def add_recipe(
     req: Request,
     payload: InRecipeSchemaRaw,
     db: AsyncSession = Depends(get_db),
-    mc: meilisearch.Client = Depends(get_mc),
+    mc: meilisearch_python_async.Client = Depends(get_mc),
 ):
     _payload = extract_ingredients(req, payload)
 
@@ -54,7 +54,7 @@ async def add_recipe(
         raise HTTPException(HTTP_400_BAD_REQUEST, "Recipe exists")
 
     await register_recipe_ingredients(db, recipe)
-    mc.index("recipes").add_documents(documents=[recipe.dict()], primary_key="id")
+    await mc.index("recipes").add_documents(documents=[recipe.dict()], primary_key="id")
 
     return recipe
 

--- a/backend/api/app/db/session.py
+++ b/backend/api/app/db/session.py
@@ -1,6 +1,6 @@
 from typing import AsyncGenerator
 
-import meilisearch
+import meilisearch_python_async
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import settings
@@ -16,6 +16,7 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         await session.commit()
 
 
-def get_mc() -> meilisearch.Client:
+async def get_mc() -> AsyncGenerator[meilisearch_python_async.Client, None]:
     """Get meiliseach client to interact with server."""
-    return meilisearch.Client(url=settings.meili_url)
+    async with meilisearch_python_async.Client(url=settings.meili_url) as client:
+        yield client

--- a/backend/api/requirements/requirements.in
+++ b/backend/api/requirements/requirements.in
@@ -8,4 +8,4 @@ fastapi-pagination
 gunicorn
 SQLAlchemy[mypy]
 spacy<3
-meilisearch
+meilisearch-python-async

--- a/backend/api/requirements/requirements.txt
+++ b/backend/api/requirements/requirements.txt
@@ -4,24 +4,31 @@
 #
 #    pip-compile --output-file=requirements/requirements.txt requirements/requirements.in
 #
+aiofiles==23.1.0
+    # via meilisearch-python-async
 alembic==1.9.3
     # via -r requirements/requirements.in
 anyio==3.6.2
-    # via starlette
+    # via
+    #   httpcore
+    #   starlette
 asyncpg==0.27.0
     # via -r requirements/requirements.in
 blis==0.7.9
     # via
     #   spacy
     #   thinc
-camel-converter[pydantic]==3.0.0
-    # via meilisearch
+camel-converter==3.0.0
+    # via meilisearch-python-async
 catalogue==1.0.2
     # via
     #   spacy
     #   thinc
 certifi==2022.12.7
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 charset-normalizer==3.0.1
     # via requests
 click==8.1.3
@@ -42,18 +49,25 @@ greenlet==2.0.2
 gunicorn==20.1.0
     # via -r requirements/requirements.in
 h11==0.14.0
-    # via uvicorn
+    # via
+    #   httpcore
+    #   uvicorn
+httpcore==0.16.3
+    # via httpx
+httpx==0.23.3
+    # via meilisearch-python-async
 idna==3.4
     # via
     #   anyio
     #   requests
+    #   rfc3986
 loguru==0.6.0
     # via -r requirements/requirements.in
 mako==1.2.4
     # via alembic
 markupsafe==2.1.2
     # via mako
-meilisearch==0.25.0
+meilisearch-python-async==1.0.0
     # via -r requirements/requirements.in
 murmurhash==1.0.9
     # via
@@ -81,15 +95,20 @@ psycopg2-binary==2.9.5
     # via -r requirements/requirements.in
 pydantic==1.10.5
     # via
-    #   camel-converter
     #   fastapi
     #   fastapi-pagination
+    #   meilisearch-python-async
+pyjwt==2.6.0
+    # via meilisearch-python-async
 requests==2.28.2
-    # via
-    #   meilisearch
-    #   spacy
+    # via spacy
+rfc3986[idna2008]==1.5.0
+    # via httpx
 sniffio==1.3.0
-    # via anyio
+    # via
+    #   anyio
+    #   httpcore
+    #   httpx
 spacy==2.3.9
     # via -r requirements/requirements.in
 sqlalchemy[mypy]==2.0.3


### PR DESCRIPTION
Since async functions are being used, this PR switches from the sync `meilisearch-python` package to the async `meilisearch-python-async` package so interactions with meilisearch are non-blocking.